### PR TITLE
OPS-1433 feat: Comment breaking change by default

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,7 @@
+<!---
 > [!WARNING]  
 > This PR introduces a **BREAKING CHANGE**
-
+-->
 ### Summary
 (Summarize the feature concisely)
 


### PR DESCRIPTION
### Summary
Change the template to not show the breaking change banner by default.
